### PR TITLE
Refine dashboard header layout and timeline display

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -232,47 +232,76 @@ button {
 .dashboard-header {
   display: flex;
   justify-content: space-between;
-  gap: 24px;
-  align-items: flex-start;
+  gap: 18px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 12px 0;
+}
+
+.header-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 260px;
 }
 
 .header-intro h1 {
-  font-size: 28px;
-  line-height: 1.2;
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+}
+
+.header-intro .helper {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
 }
 
 .metrics {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: flex-end;
-}
-
-.metric-counters {
-  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: 18px;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  flex: 1 1 320px;
 }
 
 .metric {
-  background: none;
-  border: none;
-  padding: 6px 0;
-  min-width: 108px;
   display: flex;
-  gap: 10px;
   align-items: center;
+  gap: 10px;
+  padding-left: 16px;
+  border-left: 1px solid var(--card-border);
+  min-height: 44px;
   color: inherit;
+}
+
+.metrics .metric:first-child {
+  border-left: none;
+  padding-left: 0;
+}
+
+.metric-with-icon {
+  min-width: 140px;
+}
+
+.metric-summary {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 120px;
 }
 
 .metric-icon {
   font-size: 18px;
+  color: var(--accent);
 }
 
 .metric-label {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-secondary);
 }
 
@@ -282,35 +311,6 @@ button {
   font-weight: 600;
 }
 
-.metric-rewards {
-  display: flex;
-  gap: 24px;
-  align-items: flex-end;
-  justify-content: flex-end;
-}
-
-.reward {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: flex-end;
-}
-
-.reward-label {
-  margin: 0;
-  font-size: 12px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-}
-
-.reward-value {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
 .resource-links {
   display: flex;
   gap: 12px;
@@ -318,14 +318,15 @@ button {
 }
 
 .resource-links a {
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(255, 91, 106, 0.14);
-  color: var(--text-primary);
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
 }
 
 .resource-links a:hover {
-  background: rgba(255, 91, 106, 0.22);
+  text-decoration-thickness: 2px;
+  color: var(--accent-strong);
 }
 
 .week-context {
@@ -333,10 +334,7 @@ button {
   justify-content: space-between;
   align-items: stretch;
   gap: 24px;
-  padding: 18px 24px;
-  border-radius: 18px;
-  background: rgba(18, 22, 32, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0;
   flex-wrap: wrap;
 }
 
@@ -734,12 +732,16 @@ button {
 
 @media (max-width: 960px) {
   .dashboard-header {
-    flex-direction: column;
+    align-items: flex-start;
   }
 
   .metrics {
-    width: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
+  }
+
+  .metrics .metric {
+    border-left: none;
+    padding-left: 0;
   }
 }
 

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -123,44 +123,9 @@ export function Dashboard({ user, moodResponses, onUserChange }: DashboardProps)
   const submittedPercent = assignments.length
     ? Math.round((submittedCount / assignments.length) * 100)
     : 0;
-  const weekNumbers = useMemo(() => {
-    const numbers = assignments
-      .map((assignment) => {
-        const match = assignment.slug.match(/week(\d+)/i);
-        if (!match) {
-          return null;
-        }
-        const parsed = Number.parseInt(match[1] ?? "", 10);
-        return Number.isFinite(parsed) ? parsed : null;
-      })
-      .filter((value): value is number => value !== null);
-    if (!numbers.length) {
-      return [] as number[];
-    }
-    const unique = Array.from(new Set(numbers));
-    unique.sort((a, b) => a - b);
-    return unique;
-  }, [assignments]);
-  const totalWeeks = weekNumbers.length ? weekNumbers[weekNumbers.length - 1] : 0;
-  const currentWeek = useMemo(() => {
-    const currentAssignment = assignments.find((assignment) => assignment.isCurrentDay);
-    if (currentAssignment) {
-      const match = currentAssignment.slug.match(/week(\d+)/i);
-      if (match) {
-        const parsed = Number.parseInt(match[1] ?? "", 10);
-        if (Number.isFinite(parsed)) {
-          return parsed;
-        }
-      }
-    }
-    if (weekNumbers.length) {
-      return weekNumbers[weekNumbers.length - 1];
-    }
-    return 0;
-  }, [assignments, weekNumbers]);
-  const weekProgressPercent = totalWeeks
-    ? Math.max(0, Math.min(100, Math.round((currentWeek / totalWeeks) * 100)))
-    : 0;
+  const timelineCurrentWeek = 1;
+  const timelineTotalWeeks = 12;
+  const weekProgressPercent = Math.round((timelineCurrentWeek / timelineTotalWeeks) * 100);
   const weeklyRewardEstimate = submittedCount * 15;
   const monthlyRewardEstimate = weeklyRewardEstimate * 4;
   const hasMoodResponses = Boolean(
@@ -456,38 +421,34 @@ export function Dashboard({ user, moodResponses, onUserChange }: DashboardProps)
           </p>
         </div>
         <div className="metrics" role="group" aria-label="Status metrics">
-          <div className="metric-counters">
-            <div className="metric" tabIndex={0} title="Coins you can spend unlocking future work">
-              <span className="metric-icon" aria-hidden="true">??</span>
-              <div>
-                <p className="metric-label">Coins</p>
-                <p className="metric-value">{user.coins}</p>
-              </div>
-            </div>
-            <div className="metric" tabIndex={0} title="Keep your streak alive with daily submissions">
-              <span className="metric-icon" aria-hidden="true">??</span>
-              <div>
-                <p className="metric-label">Streak</p>
-                <p className="metric-value">{user.streak} days</p>
-              </div>
-            </div>
-            <div className="metric" tabIndex={0} title="Badges show completed milestones">
-              <span className="metric-icon" aria-hidden="true">??</span>
-              <div>
-                <p className="metric-label">Badges</p>
-                <p className="metric-value">{user.badges}</p>
-              </div>
+          <div className="metric metric-with-icon" tabIndex={0} title="Coins you can spend unlocking future work">
+            <span className="metric-icon" aria-hidden="true">??</span>
+            <div>
+              <p className="metric-label">Coins</p>
+              <p className="metric-value">{user.coins}</p>
             </div>
           </div>
-          <div className="metric-rewards">
-            <div className="reward" title="Projected coins you can earn for this week's submissions">
-              <p className="reward-label">Weekly reward</p>
-              <p className="reward-value">+{weeklyRewardEstimate} coins</p>
+          <div className="metric metric-with-icon" tabIndex={0} title="Keep your streak alive with daily submissions">
+            <span className="metric-icon" aria-hidden="true">??</span>
+            <div>
+              <p className="metric-label">Streak</p>
+              <p className="metric-value">{user.streak} days</p>
             </div>
-            <div className="reward" title="Projected coins you can earn across the month">
-              <p className="reward-label">Monthly reward</p>
-              <p className="reward-value">+{monthlyRewardEstimate} coins</p>
+          </div>
+          <div className="metric metric-with-icon" tabIndex={0} title="Badges show completed milestones">
+            <span className="metric-icon" aria-hidden="true">??</span>
+            <div>
+              <p className="metric-label">Badges</p>
+              <p className="metric-value">{user.badges}</p>
             </div>
+          </div>
+          <div className="metric metric-summary" title="Projected coins you can earn for this week's submissions">
+            <p className="metric-label">Weekly reward</p>
+            <p className="metric-value">+{weeklyRewardEstimate} coins</p>
+          </div>
+          <div className="metric metric-summary" title="Projected coins you can earn across the month">
+            <p className="metric-label">Monthly reward</p>
+            <p className="metric-value">+{monthlyRewardEstimate} coins</p>
           </div>
         </div>
       </header>
@@ -497,12 +458,10 @@ export function Dashboard({ user, moodResponses, onUserChange }: DashboardProps)
           <div className="week-copy">
             <p className="eyebrow">Cohort timeline</p>
             <h2>
-              Week {currentWeek || "—"} of {totalWeeks || "—"}
+              Week {timelineCurrentWeek} of {timelineTotalWeeks}
             </h2>
             <p className="helper">
-              {totalWeeks
-                ? `You're currently pacing through week ${currentWeek} of ${totalWeeks}.`
-                : "We'll update your cohort schedule soon."}
+              You're currently pacing through week {timelineCurrentWeek} of {timelineTotalWeeks}.
             </p>
           </div>
           <div className="week-progress" aria-label="Cohort week progress">
@@ -511,15 +470,18 @@ export function Dashboard({ user, moodResponses, onUserChange }: DashboardProps)
                 <div className="progress-bar" style={{ width: `${weekProgressPercent}%` }} />
               </div>
               <span className="progress-label week-progress-label">
-                {totalWeeks ? `Week ${currentWeek}/${totalWeeks}` : "No data"}
+                Week {timelineCurrentWeek}/{timelineTotalWeeks}
               </span>
             </div>
             <div className="resource-links">
-              <a href="https://chat.openai.com" target="_blank" rel="noopener noreferrer">
-                Custom GPT for the Week
+              <a href="https://gemini.google.com" target="_blank" rel="noopener noreferrer">
+                Gemini Gem
               </a>
-              <a href="https://www.notion.so" target="_blank" rel="noopener noreferrer">
-                Notebook for the Week
+              <a href="https://chat.openai.com" target="_blank" rel="noopener noreferrer">
+                Custom GPT
+              </a>
+              <a href="https://noteboomlk.com" target="_blank" rel="noopener noreferrer">
+                NoteboomLK
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- streamline the dashboard header layout so the greeting and status chips fit within a compact row
- remove the week context card treatment, update progress copy to 1/12, and swap in the new resource links
- refresh supporting styles for metrics, timeline, and responsive behaviour to keep the header under the requested height

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7c9d9bf8832fa1f8a78185fa1405